### PR TITLE
Application4

### DIFF
--- a/src/main/java/com/netflix/imflibrary/Colorimetry.java
+++ b/src/main/java/com/netflix/imflibrary/Colorimetry.java
@@ -21,6 +21,7 @@ public enum Colorimetry {
     Color5(ColorPrimaries.ITU2020,    TransferCharacteristic.ITU2020,           CodingEquation.ITU2020NCL),
     Color6(ColorPrimaries.P3D65,      TransferCharacteristic.SMPTEST2084,       CodingEquation.None),
     Color7(ColorPrimaries.ITU2020,    TransferCharacteristic.SMPTEST2084,       CodingEquation.ITU2020NCL),
+    Color_App4_Lin(ColorPrimaries.XYZ,    TransferCharacteristic.Linear,       CodingEquation.None),
     Color_App5_AP0(ColorPrimaries.ACES,    TransferCharacteristic.Linear,       CodingEquation.None),
     Unknown(ColorPrimaries.Unknown,   TransferCharacteristic.Unknown,           CodingEquation.Unknown);
 
@@ -115,6 +116,7 @@ public enum Colorimetry {
         ITU2020(UL.fromULAsURNStringToUL("urn:smpte:ul:06.0E.2B.34.04.01.01.0D.04.01.01.01.03.04.00.00")),
         P3D65(UL.fromULAsURNStringToUL("urn:smpte:ul:06.0E.2B.34.04.01.01.0D.04.01.01.01.03.06.00.00")),
         ACES(UL.fromULAsURNStringToUL("urn:smpte:ul:06.0e.2b.34.04.01.01.0d.04.01.01.01.03.07.00.00")),
+        XYZ(UL.fromULAsURNStringToUL("urn:smpte:ul:06.0e.2b.34.04.01.01.0d.04.01.01.01.03.08.00.00")),
         Unknown(null);
 
         private final UL colorPrimariesUL;

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application4Composition.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application4Composition.java
@@ -86,6 +86,9 @@ public class Application4Composition extends AbstractApplicationComposition {
 
         try
         {
+            // Validate CPL Constraints
+            validateCompositionPlaylist(imfCompositionPlaylistType, ApplicationCompositionType.APPLICATION_4_COMPOSITION_TYPE, imfErrorLogger);
+            // Validate Image Essence Constraints
             CompositionImageEssenceDescriptorModel imageEssenceDescriptorModel = getCompositionImageEssenceDescriptorModel();
 
             if (imageEssenceDescriptorModel != null)
@@ -99,6 +102,43 @@ public class Application4Composition extends AbstractApplicationComposition {
                     IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
                     String.format("Exception in validating EssenceDescriptors in APPLICATION_4_COMPOSITION_TYPE: %s ", e.getMessage()));
         }
+    }
+
+    public static void validateCompositionPlaylist(IMFCompositionPlaylistType imfCompositionPlaylistType,
+                                                   ApplicationCompositionFactory.ApplicationCompositionType applicationCompositionType,
+                                                   IMFErrorLogger imfErrorLogger)
+    {
+        //ContentKind
+        String contentKind = imfCompositionPlaylistType.getContentKind();
+        if(contentKind == null) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("ContentKind shall be present as per %s", applicationCompositionType.toString()));
+        }
+
+        //Creator
+        String creator = imfCompositionPlaylistType.getCreator();
+        if(creator == null) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("Creator shall be present as per %s", applicationCompositionType.toString()));
+        }
+
+        //Issuer
+        String issuer = imfCompositionPlaylistType.getIssuer();
+        if(issuer == null) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("Issuer shall be present as per %s", applicationCompositionType.toString()));
+        }
+
+        //ContentVersionList
+        if( imfCompositionPlaylistType.getContentVersionList().getContentVersions().size() == 0) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("At least one ContentVersion shall be present as per %s", applicationCompositionType.toString()));
+        }
+
     }
 
 

--- a/src/main/java/com/netflix/imflibrary/st2067_2/Application4Composition.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/Application4Composition.java
@@ -1,0 +1,269 @@
+/*
+ *
+ * Copyright 2019 Eclair Media SAS.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+package com.netflix.imflibrary.st2067_2;
+
+import com.netflix.imflibrary.Colorimetry;
+import com.netflix.imflibrary.Colorimetry.ColorModel;
+import com.netflix.imflibrary.Colorimetry.Quantization;
+import com.netflix.imflibrary.Colorimetry.Sampling;
+import com.netflix.imflibrary.IMFErrorLogger;
+import com.netflix.imflibrary.IMFErrorLoggerImpl;
+import com.netflix.imflibrary.st0377.header.UL;
+import com.netflix.imflibrary.st0422.JP2KContentKind;
+import com.netflix.imflibrary.st2067_2.ApplicationCompositionFactory.ApplicationCompositionType;
+import com.netflix.imflibrary.utils.Fraction;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.netflix.imflibrary.Colorimetry.CodingEquation;
+import static com.netflix.imflibrary.Colorimetry.ColorModel;
+import static com.netflix.imflibrary.Colorimetry.ColorPrimaries;
+import static com.netflix.imflibrary.Colorimetry.Quantization;
+import static com.netflix.imflibrary.Colorimetry.Sampling;
+import static com.netflix.imflibrary.Colorimetry.TransferCharacteristic;
+import static com.netflix.imflibrary.st0377.header.GenericPictureEssenceDescriptor.FrameLayoutType;
+
+
+/**
+ * A class that models Composition with Application 4 constraints from 2067-40 specification
+ */
+public class Application4Composition extends AbstractApplicationComposition {
+    public static final Integer MAX_XYZ_IMAGE_FRAME_WIDTH = 8192;
+    public static final Integer MAX_XYZ_IMAGE_FRAME_HEIGHT = 6224;
+    public static final Set<Fraction>sampleRateSupported = Collections.unmodifiableSet(new HashSet<Fraction>() {{
+        add(new Fraction(16)); add(new Fraction(200, 11)); add(new Fraction(20)); add(new Fraction(240, 11)); add(new Fraction(24)); add(new Fraction(25));
+        add(new Fraction(30)); add(new Fraction(48)); add(new Fraction(50)); add(new Fraction(60)); add(new Fraction(100)); add(new Fraction(120));}});
+    public static final Map<Colorimetry, Set<Integer>>colorToBitDepthMap = Collections.unmodifiableMap(new HashMap<Colorimetry, Set<Integer>>() {{
+        put(Colorimetry.Unknown, new HashSet<Integer>(){{ }});
+        put(Colorimetry.Color_App4_Lin, new HashSet<Integer>(){{ add(16); }});
+    }});
+    public static final Set<Integer>bitDepthsSupported = Collections.unmodifiableSet(new HashSet<Integer>() {{
+        add(16); }});
+
+    private static final Set<String> ignoreSet = Collections.unmodifiableSet(new HashSet<String>() {{
+        add("SignalStandard");
+        add("ActiveFormatDescriptor");
+        add("VideoLineMap");
+        add("AlphaTransparency");
+        add("StoredF2Offset");
+        add("SampledYOffset");
+        add("Image Alignment Offset");
+        add("Image Start Offset");
+        add("Image End Offset");
+        add("FieldDominance");
+        add("Coding Equations");
+        add("Alternative Center Cuts");
+    }});
+
+    public Application4Composition(@Nonnull IMFCompositionPlaylistType imfCompositionPlaylistType) {
+        this(imfCompositionPlaylistType, new HashSet<>());
+    }
+
+    public Application4Composition(@Nonnull IMFCompositionPlaylistType imfCompositionPlaylistType, Set<String> homogeneitySelectionSet) {
+
+        super(imfCompositionPlaylistType, ignoreSet, homogeneitySelectionSet);
+
+        try
+        {
+            CompositionImageEssenceDescriptorModel imageEssenceDescriptorModel = getCompositionImageEssenceDescriptorModel();
+
+            if (imageEssenceDescriptorModel != null)
+            {
+                Application4Composition.validateGenericPictureEssenceDescriptor(imageEssenceDescriptorModel, ApplicationCompositionType.APPLICATION_4_COMPOSITION_TYPE, imfErrorLogger);
+                Application4Composition.validateImageCharacteristics(imageEssenceDescriptorModel, ApplicationCompositionType.APPLICATION_4_COMPOSITION_TYPE, imfErrorLogger);
+            }
+        }
+        catch (Exception e) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("Exception in validating EssenceDescriptors in APPLICATION_4_COMPOSITION_TYPE: %s ", e.getMessage()));
+        }
+    }
+
+
+    public static void validateGenericPictureEssenceDescriptor(CompositionImageEssenceDescriptorModel imageEssenceDescriptorModel,
+                                                               ApplicationCompositionFactory.ApplicationCompositionType applicationCompositionType,
+                                                               IMFErrorLogger imfErrorLogger)
+    {
+        UUID imageEssenceDescriptorID = imageEssenceDescriptorModel.getImageEssencedescriptorID();
+
+        ColorModel colorModel = imageEssenceDescriptorModel.getColorModel();
+        if( colorModel.equals(ColorModel.Unknown)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has Invalid color components as per %s",
+                            imageEssenceDescriptorID.toString(), applicationCompositionType.toString()));
+            return;
+        }
+
+        Integer storedWidth = imageEssenceDescriptorModel.getStoredWidth();
+        Integer storedHeight = imageEssenceDescriptorModel.getStoredHeight();
+        if ((storedWidth <= 0) || (storedHeight <= 0)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid storedWidth(%d) or storedHeight(%d) as per %s",
+                            imageEssenceDescriptorID.toString(), storedWidth, storedHeight, applicationCompositionType.toString()));
+        }
+
+        Integer sampleWidth = imageEssenceDescriptorModel.getSampleWidth();
+        Integer sampleHeight = imageEssenceDescriptorModel.getSampleHeight();
+        if ((sampleWidth != null && !sampleWidth.equals(storedWidth)) ||
+                (sampleHeight != null && !sampleHeight.equals(storedHeight))) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid sampleWidth(%d) or sampleHeight(%d) as per %s",
+                            imageEssenceDescriptorID.toString(), sampleWidth != null ? sampleWidth : 0, sampleHeight != null ? sampleHeight : 0,
+                            applicationCompositionType.toString()));
+        }
+
+        if( imageEssenceDescriptorModel.getStoredOffset() != null) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s invalid StoredOffset as per %s",
+                            imageEssenceDescriptorID.toString(), applicationCompositionType.toString()));
+        }
+
+        ColorPrimaries colorPrimaries = imageEssenceDescriptorModel.getColorPrimaries();
+        if(colorPrimaries.equals(ColorPrimaries.Unknown)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid ColorPrimaries as per %s",
+                            imageEssenceDescriptorID.toString(), applicationCompositionType.toString()));
+        }
+
+        TransferCharacteristic transferCharacteristic = imageEssenceDescriptorModel.getTransferCharacteristic();
+        if(transferCharacteristic.equals(TransferCharacteristic.Unknown)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid TransferCharacteristic as per %s",
+                            imageEssenceDescriptorID.toString(), applicationCompositionType.toString()));
+        }
+
+        Colorimetry color = imageEssenceDescriptorModel.getColor();
+        if(color.equals(Colorimetry.Unknown)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid ColorPrimaries(%s)-TransferCharacteristic(%s) combination as per %s",
+                            imageEssenceDescriptorID.toString(), colorPrimaries.name(), transferCharacteristic.name(), applicationCompositionType.toString()));
+        }
+
+        FrameLayoutType frameLayoutType = imageEssenceDescriptorModel.getFrameLayoutType();
+        UL essenceContainerFormatUL = imageEssenceDescriptorModel.getEssenceContainerFormatUL();
+        if(essenceContainerFormatUL != null) {
+            JP2KContentKind contentKind = JP2KContentKind.valueOf(essenceContainerFormatUL.getULAsBytes()[14]);
+            if ((frameLayoutType.equals(FrameLayoutType.FullFrame) && !contentKind.equals(JP2KContentKind.P1))) {
+                imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                        IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                        String.format("EssenceDescriptor with ID %s has invalid JPEG-2000 ContentKind (%s) indicated by the ContainerFormat as per %s",
+                                imageEssenceDescriptorID.toString(), contentKind, applicationCompositionType.toString()));
+            }
+        }
+   }
+
+    public static void validateImageCharacteristics(CompositionImageEssenceDescriptorModel imageEssenceDescriptorModel,
+                                                    ApplicationCompositionType applicationCompositionType,
+                                                    IMFErrorLogger imfErrorLogger)
+    {
+        UUID imageEssenceDescriptorID = imageEssenceDescriptorModel.getImageEssencedescriptorID();
+
+        ColorModel colorModel = imageEssenceDescriptorModel.getColorModel();
+        if( !colorModel.equals(ColorModel.RGB) ) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("XYZ EssenceDescriptor with ID %s has Invalid color components as per %s",
+                            imageEssenceDescriptorID.toString(), applicationCompositionType.toString()));
+            return;
+        }
+
+        //storedWidth
+        Integer storedWidth = imageEssenceDescriptorModel.getStoredWidth();
+        if ((storedWidth > MAX_XYZ_IMAGE_FRAME_WIDTH)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid StoredWidth(%d) for ColorModel(%s) as per %s",
+                            imageEssenceDescriptorID.toString(), storedWidth, colorModel.name(), applicationCompositionType.toString()));
+        }
+
+        //storedHeight
+        Integer storedHeight = imageEssenceDescriptorModel.getStoredHeight();
+        if ((storedHeight > MAX_XYZ_IMAGE_FRAME_HEIGHT)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid storedHeight(%d) for ColorModel(%s) as per %s",
+                            imageEssenceDescriptorID.toString(), storedHeight, colorModel.name(), applicationCompositionType.toString()));
+        }
+
+        //PixelBitDepth
+        Integer pixelBitDepth = imageEssenceDescriptorModel.getPixelBitDepth();
+        Colorimetry color = imageEssenceDescriptorModel.getColor();
+        if( !bitDepthsSupported.contains(pixelBitDepth) || !colorToBitDepthMap.get(color).contains(pixelBitDepth)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s invalid PixelBitDepth(%d) for Color(%s) as per %s",
+                            imageEssenceDescriptorID.toString(), pixelBitDepth, color.name(), applicationCompositionType.toString()));
+        }
+
+        //FrameLayout
+        FrameLayoutType frameLayoutType = imageEssenceDescriptorModel.getFrameLayoutType();
+        if (!frameLayoutType.equals(FrameLayoutType.FullFrame)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has invalid FrameLayout(%s) as per %s",
+                            imageEssenceDescriptorID.toString(), frameLayoutType.name(), applicationCompositionType.toString()));
+        }
+
+        //SampleRate
+        Fraction sampleRate = imageEssenceDescriptorModel.getSampleRate();
+        Set<Fraction> frameRateSupported = sampleRateSupported;
+        if (!frameRateSupported.contains(sampleRate)) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has Invalid SampleRate(%s) for ColorModel(%s) as per %s",
+                            imageEssenceDescriptorID.toString(), sampleRate.toString(), colorModel.name(), applicationCompositionType.toString()));
+        }
+
+        //Sampling
+        Sampling sampling = imageEssenceDescriptorModel.getSampling();
+        if((!sampling.equals(Sampling.Sampling444))) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has Invalid Sampling(%s) for ColorModel(%s) as per %s",
+                            imageEssenceDescriptorID.toString(), sampling.name(), colorModel.name(), applicationCompositionType.toString()));
+        }
+
+        //Quantization
+        Quantization quantization = imageEssenceDescriptorModel.getQuantization();
+        if(!(quantization.equals(Quantization.QE2))) {
+            imfErrorLogger.addError(IMFErrorLogger.IMFErrors.ErrorCodes.APPLICATION_COMPOSITION_ERROR,
+                    IMFErrorLogger.IMFErrors.ErrorLevels.NON_FATAL,
+                    String.format("EssenceDescriptor with ID %s has Invalid Quantization(%s) for ColorModel(%s) as per %s",
+                            imageEssenceDescriptorID.toString(), quantization.name(), colorModel.name(), applicationCompositionType.toString()));
+        }
+    }
+
+    public ApplicationCompositionType getApplicationCompositionType() {
+        return ApplicationCompositionType.APPLICATION_4_COMPOSITION_TYPE;
+    }
+
+}

--- a/src/main/java/com/netflix/imflibrary/st2067_2/ApplicationCompositionFactory.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/ApplicationCompositionFactory.java
@@ -46,6 +46,10 @@ public class ApplicationCompositionFactory {
         add("http://www.smpte-ra.org/schemas/2067-21/2016");
     }});
 
+    private static final Set<String> namespacesApplication4Composition = Collections.unmodifiableSet(new HashSet<String>() {{
+        add("http://www.smpte-ra.org/schemas/2067-40/2016");
+    }});
+
     private static final Set<String> namespacesApplication5Composition = Collections.unmodifiableSet(new HashSet<String>() {{
         add("http://www.smpte-ra.org/ns/2067-50/2017");
     }});
@@ -53,6 +57,7 @@ public class ApplicationCompositionFactory {
     public enum ApplicationCompositionType {
         APPLICATION_2_COMPOSITION_TYPE(Application2Composition.class,          namespacesApplication2Composition),
         APPLICATION_2E_COMPOSITION_TYPE(Application2ExtendedComposition.class, namespacesApplication2EComposition),
+        APPLICATION_4_COMPOSITION_TYPE(Application4Composition.class,          namespacesApplication4Composition),
         APPLICATION_5_COMPOSITION_TYPE(Application5Composition.class,          namespacesApplication5Composition),
         APPLICATION_UNSUPPORTED_COMPOSITION_TYPE(ApplicationUnsupportedComposition.class, Collections.unmodifiableSet(new HashSet<>()));
         private Set<String> nameSpaceSet;

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionModel_st2067_2_2013.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionModel_st2067_2_2013.java
@@ -4,6 +4,7 @@ import com.netflix.imflibrary.IMFErrorLogger;
 import com.netflix.imflibrary.exceptions.IMFException;
 import com.netflix.imflibrary.utils.UUIDHelper;
 import com.netflix.imflibrary.writerTools.CompositionPlaylistBuilder_2013;
+
 import org.w3c.dom.Element;
 
 
@@ -13,8 +14,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -189,6 +192,11 @@ final class CompositionModel_st2067_2_2013 {
             }
         }
 
+        Map<String, String> contentVersionList = new HashMap<String, String>();
+        for (org.smpte_ra.schemas.st2067_2_2013.ContentVersionType entry : compositionPlaylistType.getContentVersionList().getContentVersion()) {
+            contentVersionList.put(entry.getId(), entry.getLabelText().getValue());
+        }
+
         return new IMFCompositionPlaylistType(compositionPlaylistType.getId(),
                 compositionPlaylistType.getEditRate(),
                 (compositionPlaylistType.getAnnotation() == null ? null : compositionPlaylistType.getAnnotation().getValue()),
@@ -196,6 +204,8 @@ final class CompositionModel_st2067_2_2013 {
                 (compositionPlaylistType.getCreator() == null ? null : compositionPlaylistType.getCreator().getValue()),
                 (compositionPlaylistType.getContentOriginator() == null ? null : compositionPlaylistType.getContentOriginator().getValue()),
                 (compositionPlaylistType.getContentTitle() == null ? null : compositionPlaylistType.getContentTitle().getValue()),
+                (compositionPlaylistType.getContentKind() == null ? null : compositionPlaylistType.getContentKind().getValue()),
+                contentVersionList,
                 Collections.synchronizedList(segmentList),
                 Collections.synchronizedList(essenceDescriptorList),
                 "org.smpte_ra.schemas.st2067_2_2013", applicationIDs);

--- a/src/main/java/com/netflix/imflibrary/st2067_2/CompositionModel_st2067_2_2016.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/CompositionModel_st2067_2_2016.java
@@ -13,8 +13,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -205,6 +207,11 @@ final class CompositionModel_st2067_2_2016 {
             }
         }
 
+        Map<String, String> contentVersionList = new HashMap<String, String>();
+        for (org.smpte_ra.schemas.st2067_2_2016.ContentVersionType entry : compositionPlaylistType.getContentVersionList().getContentVersion()) {
+            contentVersionList.put(entry.getId(), entry.getLabelText().getValue());
+        }
+
         return new IMFCompositionPlaylistType( compositionPlaylistType.getId(),
                 compositionPlaylistType.getEditRate(),
                 (compositionPlaylistType.getAnnotation() == null ? null : compositionPlaylistType.getAnnotation().getValue()),
@@ -212,6 +219,8 @@ final class CompositionModel_st2067_2_2016 {
                 (compositionPlaylistType.getCreator() == null ? null : compositionPlaylistType.getCreator().getValue()),
                 (compositionPlaylistType.getContentOriginator() == null ? null : compositionPlaylistType.getContentOriginator().getValue()),
                 (compositionPlaylistType.getContentTitle() == null ? null : compositionPlaylistType.getContentTitle().getValue()),
+                (compositionPlaylistType.getContentKind() == null ? null : compositionPlaylistType.getContentKind().getValue()),
+                contentVersionList,
                 Collections.synchronizedList(segmentList),
                 Collections.synchronizedList(essenceDescriptorList),
                 "org.smpte_ra.schemas.st2067_2_2016", applicationIDs

--- a/src/main/java/com/netflix/imflibrary/st2067_2/IMFCompositionPlaylistType.java
+++ b/src/main/java/com/netflix/imflibrary/st2067_2/IMFCompositionPlaylistType.java
@@ -62,6 +62,8 @@ final class IMFCompositionPlaylistType {
     private final String creator;
     private final String contentOriginator;
     private final String contentTitle;
+    private final String contentKind;
+    private final Composition.ContentVersionList contentVersionList;
     private final List<IMFSegmentType> segmentList;
     private final List<IMFEssenceDescriptorBaseType> essenceDescriptorList;
     private final IMFErrorLogger imfErrorLogger;
@@ -82,12 +84,14 @@ final class IMFCompositionPlaylistType {
                                       String creator,
                                       String contentOriginator,
                                       String contentTitle,
+                                      String contentKind,
+                                      Map<String, String> contentVersionList,
                                       List<IMFSegmentType> segmentList,
                                       List<IMFEssenceDescriptorBaseType> essenceDescriptorList,
                                       String coreConstraintsVersion,
                                       String applicationId)
     {
-        this(id, editRate, annotation, issuer, creator, contentOriginator, contentTitle, segmentList, essenceDescriptorList, coreConstraintsVersion, (applicationId == null ? new HashSet<>() : new HashSet<String>(Arrays.asList(applicationId))));
+        this(id, editRate, annotation, issuer, creator, contentOriginator, contentTitle, contentKind, contentVersionList, segmentList, essenceDescriptorList, coreConstraintsVersion, (applicationId == null ? new HashSet<>() : new HashSet<String>(Arrays.asList(applicationId))));
     }
 
     public IMFCompositionPlaylistType(String id,
@@ -97,6 +101,8 @@ final class IMFCompositionPlaylistType {
                                    String creator,
                                    String contentOriginator,
                                    String contentTitle,
+                                   String contentKind,
+                                   Map<String, String> contentVersionList,
                                    List<IMFSegmentType> segmentList,
                                    List<IMFEssenceDescriptorBaseType> essenceDescriptorList,
                                    String coreConstraintsVersion,
@@ -104,10 +110,12 @@ final class IMFCompositionPlaylistType {
     {
         this.id                = UUIDHelper.fromUUIDAsURNStringToUUID(id);
         Composition.EditRate rate = null;
+        Composition.ContentVersionList versions = null;
         imfErrorLogger = new IMFErrorLoggerImpl();
         try
         {
             rate = new Composition.EditRate(editRate);
+            versions = new Composition.ContentVersionList(contentVersionList);
         }
         catch(IMFException e)
         {
@@ -120,6 +128,8 @@ final class IMFCompositionPlaylistType {
         this.creator           = creator;
         this.contentOriginator = contentOriginator;
         this.contentTitle      = contentTitle;
+        this.contentKind       = contentKind;
+        this.contentVersionList= versions;
         this.segmentList       = segmentList;
         this.essenceDescriptorList  = essenceDescriptorList;
         this.coreConstraintsVersion = coreConstraintsVersion;
@@ -430,6 +440,22 @@ final class IMFCompositionPlaylistType {
      */
     public String getContentTitle(){
         return this.contentTitle;
+    }
+
+    /**
+     * Getter for the Composition Playlist contentKind
+     * @return a string representing contentKind of the Composition Playlist
+     */
+    public String getContentKind(){
+        return this.contentKind;
+    }
+
+    /**
+     * Getter for the Composition Playlist contentVersionList
+     * @return an object representing contentVersionList of the Composition Playlist
+     */
+    public Composition.ContentVersionList getContentVersionList(){
+        return this.contentVersionList;
     }
 
     /**


### PR DESCRIPTION
This Pull Request implement support for IMF Application 4, as specified in SMPTE ST 2067-40:2016.

> IMF Application # 4 is a specialization of the IMF Framework, and is intended to exchange content of cinematographic work after digital postproduction either sourced from film or from digital media and can be used in a preservation framework. It specifies:
>  - images encoded using 16-bit XYZ color primaries and a linear transfer function;
>  - maximum image frame width and height of 8192 and 6224 pixels, respectively; and
>  - a constrained Composition structure that mimics the segmentation of movie into individual reels.

As of today, the checks done are not exhaustive, here is some of the parts that could be added :
*  If Mastering Display metadata is present, shall conform to the list defined in 6.1.2.1.5
*  If Mastering Display White Point Chromaticity metadata is present, shall conform to the list defined in 6.1.2.1.6
*  RGBA Picture Essence Descriptor's Pixel Layout item shall conform to 6.1.2.2.3. I'm not really sure about this, the code seems a bit messy in checking PixelLayout right now, there is code for Application 2 and 5 mixed in the CompositionImageEssenceDescriptorModel.java file. If anyone as a recommandation on this, I would be interested to hear it.
*  CompositionPlayList timeline related constraints (Section 7.8 through 7.10) 
 
A few test cases (CPLs) will probably be added as soon as possible.